### PR TITLE
feat: add background cron jobs for data sync

### DIFF
--- a/cmd/api_server.go
+++ b/cmd/api_server.go
@@ -51,6 +51,9 @@ func ApiServer(dbPath string, port int, debug bool) {
 	}()
 
 	repo := internal.NewFuelPricesRepository(db)
+	if _, err := internal.StartCron(client, repo); err != nil {
+		log.Fatalf("failed to start CRON jobs: %v", err)
+	}
 
 	r := gin.New()
 
@@ -89,46 +92,3 @@ func ApiServer(dbPath string, port int, debug bool) {
 		log.Fatalf("HTTP API Server failed to start on port %d: %v", port, err)
 	}
 }
-
-// func main() {
-
-// 	db, err := internal.Connect("data/fuel_prices.db")
-// 	if err != nil {
-// 		log.Fatalf("Database connection failed: %v", err)
-// 		return
-// 	}
-// 	defer func() {
-// 		if err := db.Close(); err != nil {
-// 			log.Fatalf("Failed to close database: %v", err)
-// 		}
-// 	}()
-// 	repo := internal.NewFuelPricesRepository(db)
-
-// 	clientId := os.Getenv("CLIENT_ID")
-// 	clientSecret := os.Getenv("CLIENT_SECRET")
-
-// 	client, err := internal.NewFuelPricesClient(clientId, clientSecret)
-// 	if err != nil {
-// 		log.Fatalf("Authentication failed: %v\n", err)
-// 	}
-
-// 	count := 0
-// 	for {
-// 		if count%4 == 0 {
-// 			numPFS, err := client.GetFillingStations(repo.InsertPFS)
-// 			if err != nil {
-// 				log.Fatalf("Error fetching PFS: %v\n", err)
-// 			}
-// 			log.Printf("Inserted %d PFS", numPFS)
-// 		}
-
-// 		numPrices, err := client.GetFuelPrices(repo.InsertPrices)
-// 		if err != nil {
-// 			log.Fatalf("Error fetching fuel prices: %v\n", err)
-// 		}
-// 		log.Printf("Inserted %d price records", numPrices)
-
-// 		time.Sleep(15 * time.Minute)
-// 		count++
-// 	}
-// }

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/rm-hull/godx v0.2.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	github.com/tavsec/gin-healthcheck v1.7.13
 )

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,8 @@ github.com/redis/go-redis/v9 v9.17.3 h1:fN29NdNrE17KttK5Ndf20buqfDZwGNgoUr9qjl1D
 github.com/redis/go-redis/v9 v9.17.3/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/rm-hull/godx v0.2.0 h1:ksnqwJXh4EV2l0bBPCYmzWMVC8oip9F2oQV9mNWZgDo=
 github.com/rm-hull/godx v0.2.0/go.mod h1:bVa3+ZY0TgOvwrlhDb4kngU8L63BlqcwSYu63GCHowQ=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=

--- a/internal/cron.go
+++ b/internal/cron.go
@@ -1,0 +1,42 @@
+package internal
+
+import (
+	"log"
+
+	"github.com/robfig/cron/v3"
+)
+
+const CRON_SCHEDULE_PFS = "0 */6 * * *"     // Every 6 hours
+const CRON_SCHEDULE_PRICES = "10 */1 * * *" // Every hour
+
+func StartCron(client FuelPricesClient, repo FuelPricesRepository) (*cron.Cron, error) {
+
+	c := cron.New()
+
+	log.Print("Starting CRON jobs to update petrol filling stations and fuel prices")
+
+	if _, err := c.AddFunc(CRON_SCHEDULE_PFS, func() {
+		numPFS, err := client.GetFillingStations(repo.InsertPFS)
+		if err != nil {
+			log.Printf("Error fetching PFS: %v\n", err)
+			return
+		}
+		log.Printf("Inserted %d PFS", numPFS)
+	}); err != nil {
+		return nil, err
+	}
+
+	if _, err := c.AddFunc(CRON_SCHEDULE_PRICES, func() {
+		numPrices, err := client.GetFuelPrices(repo.InsertPrices)
+		if err != nil {
+			log.Printf("Error fetching fuel prices: %v\n", err)
+			return
+		}
+		log.Printf("Inserted %d fuel prices", numPrices)
+	}); err != nil {
+		return nil, err
+	}
+
+	c.Start()
+	return c, nil
+}


### PR DESCRIPTION
Introduces a background task scheduler using `robfig/cron` to automate data synchronization, replacing manual polling logic.

*   Added `internal/cron.go` to manage scheduled updates.
*   **Filling Stations**: Synchronized every 6 hours.
*   **Fuel Prices**: Synchronized every hour.
*   Integrates the scheduler into the `ApiServer` startup sequence.

```mermaid
sequenceDiagram
    participant S as API Server
    participant C as Cron Manager
    participant E as External API
    participant R as Repository

    S->>C: StartCron(client, repo)
    Note over C: Scheduler Starts
    par Every 6 Hours
        C->>E: GetFillingStations()
        E->>R: InsertPFS()
    and Every 1 Hour
        C->>E: GetFuelPrices()
        E->>R: InsertPrices()
    end
```