### PR TITLE
feat: add flexible refresh policies for API

### DIFF
--- a/cmd/api_server.go
+++ b/cmd/api_server.go
@@ -19,9 +19,9 @@ import (
 	hc_config "github.com/tavsec/gin-healthcheck/config"
 )
 
-func ApiServer(dbPath string, port int, fullRefresh, debug bool) error {
+func ApiServer(dbPath string, port int, refresh string, debug bool) error {
 
-	client, repo, err := bootstrap(dbPath, fullRefresh, debug)
+	client, repo, err := bootstrap(dbPath, refresh, debug)
 	if err != nil {
 		return err
 	}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -20,7 +20,7 @@ import (
 // bootstrap initialises shared resources used by both the API server and import
 // commands. It returns the authenticated client, a repository, and an error
 // if something failed during startup.
-func bootstrap(dbPath string, fullRefresh, debug bool) (internal.FuelPricesClient, internal.FuelPricesRepository, error) {
+func bootstrap(dbPath, refresh string, debug bool) (internal.FuelPricesClient, internal.FuelPricesRepository, error) {
 	if err := godotenv.Load(); err != nil {
 		log.Println("No .env file found")
 	}
@@ -48,7 +48,7 @@ func bootstrap(dbPath string, fullRefresh, debug bool) (internal.FuelPricesClien
 	clientId := os.Getenv("CLIENT_ID")
 	clientSecret := os.Getenv("CLIENT_SECRET")
 
-	client, err := internal.NewFuelPricesClient(clientId, clientSecret, fullRefresh)
+	client, err := internal.NewFuelPricesClient(clientId, clientSecret, refresh)
 	if err != nil {
 		return nil, nil, fmt.Errorf("GOV.UK authentication failed: %w", err)
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -7,7 +7,7 @@ import (
 
 func Import(dbPath string) error {
 
-	client, repo, err := bootstrap(dbPath, true, true)
+	client, repo, err := bootstrap(dbPath, "full", true)
 	if err != nil {
 		return err
 	}

--- a/internal/client_fetch.go
+++ b/internal/client_fetch.go
@@ -103,10 +103,7 @@ func NewFuelPricesClient(clientId, clientSecret string, refresh string) (FuelPri
 }
 
 func (mgr *fuelPricesManager) ShouldRefresh() bool {
-	if mgr.refresh == "never" {
-		return false
-	}
-	return true
+	return mgr.refresh != "never"
 }
 
 func (mgr *fuelPricesManager) LastUpdated() *time.Time {

--- a/internal/client_fetch.go
+++ b/internal/client_fetch.go
@@ -51,6 +51,7 @@ func (e *HTTPStatusError) Error() string {
 type BatchCallback[T any] func([]T) (int, int, error)
 
 type FuelPricesClient interface {
+	ShouldRefresh() bool
 	GetFuelPrices(BatchCallback[models.ForecourtPrices]) (int, int, error)
 	GetFillingStations(BatchCallback[models.PetrolFillingStation]) (int, int, error)
 	LastUpdated() *time.Time
@@ -70,10 +71,10 @@ type fuelPricesManager struct {
 	timeTracker timeTracker
 	client      *http.Client
 	metrics     *metrics.ClientFetchMetrics
-	fullRefresh bool
+	refresh     string
 }
 
-func NewFuelPricesClient(clientId, clientSecret string, fullRefresh bool) (FuelPricesClient, error) {
+func NewFuelPricesClient(clientId, clientSecret string, refresh string) (FuelPricesClient, error) {
 	baseUrl := "https://www.fuel-finder.service.gov.uk/api/v1"
 	if envBaseUrl := os.Getenv("FUEL_PRICES_API_BASE_URL"); envBaseUrl != "" {
 		baseUrl = envBaseUrl
@@ -84,8 +85,8 @@ func NewFuelPricesClient(clientId, clientSecret string, fullRefresh bool) (FuelP
 		timeTracker: timeTracker{
 			started: time.Now(),
 		},
-		fullRefresh: fullRefresh,
-		client:      &http.Client{},
+		refresh: refresh,
+		client:  &http.Client{},
 		authReq: models.AuthRequest{
 			ClientId:     clientId,
 			ClientSecret: clientSecret,
@@ -99,6 +100,13 @@ func NewFuelPricesClient(clientId, clientSecret string, fullRefresh bool) (FuelP
 	}
 
 	return mgr, nil
+}
+
+func (mgr *fuelPricesManager) ShouldRefresh() bool {
+	if mgr.refresh == "never" {
+		return false
+	}
+	return true
 }
 
 func (mgr *fuelPricesManager) LastUpdated() *time.Time {
@@ -217,7 +225,7 @@ func (mgr *fuelPricesManager) checkTokenExpiry() error {
 
 func (mgr *fuelPricesManager) getEffectiveStartTimestamp(path string, lastFetch *time.Time) string {
 
-	if lastFetch == nil || lastFetch.IsZero() || mgr.fullRefresh {
+	if lastFetch == nil || lastFetch.IsZero() || mgr.refresh == "full" {
 		return ""
 	}
 

--- a/internal/client_fetch_test.go
+++ b/internal/client_fetch_test.go
@@ -41,8 +41,8 @@ func setupTestClient(t *testing.T, baseUrl string) *fuelPricesManager {
 		timeTracker: timeTracker{
 			started: time.Now(),
 		},
-		fullRefresh: false,
-		client:      &http.Client{},
+		refresh: "incremental",
+		client:  &http.Client{},
 		authReq: models.AuthRequest{
 			ClientId:     "test-client-id",
 			ClientSecret: "test-client-secret",
@@ -275,17 +275,17 @@ func TestGetFillingStations_Success(t *testing.T) {
 }
 
 func TestGetEffectiveStartTimestamp(t *testing.T) {
-	mgr := &fuelPricesManager{fullRefresh: false}
+	mgr := &fuelPricesManager{refresh: "incremental"}
 	lastFetch := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
 
 	ts := mgr.getEffectiveStartTimestamp("path", &lastFetch)
 	assert.Equal(t, "2023-01-01 12:00:00", ts)
 
-	mgr.fullRefresh = true
+	mgr.refresh = "full"
 	ts = mgr.getEffectiveStartTimestamp("path", &lastFetch)
 	assert.Equal(t, "", ts)
 
-	mgr.fullRefresh = false
+	mgr.refresh = "incremental"
 	ts = mgr.getEffectiveStartTimestamp("path", nil)
 	assert.Equal(t, "", ts)
 }
@@ -374,7 +374,7 @@ func TestNewFuelPricesClient(t *testing.T) {
 
 	t.Setenv("FUEL_PRICES_API_BASE_URL", server.URL)
 
-	client, err := NewFuelPricesClient("id", "secret", false)
+	client, err := NewFuelPricesClient("id", "secret", "incremental")
 	require.NoError(t, err)
 	assert.NotNil(t, client)
 }

--- a/internal/cron.go
+++ b/internal/cron.go
@@ -16,6 +16,10 @@ func StartCron(client FuelPricesClient, repo FuelPricesRepository) (*cron.Cron, 
 	log.Print("Starting CRON jobs to update petrol filling stations and fuel prices")
 
 	if _, err := c.AddFunc(CRON_SCHEDULE_PFS, func() {
+		if !client.ShouldRefresh() {
+			log.Print("Skipping filling stations fetch due to refresh policy")
+			return
+		}
 		numPFS, dropped, err := client.GetFillingStations(repo.InsertPFS)
 		if err != nil {
 			log.Printf("Error fetching PFS: %v (dropped: %d) \n", err, dropped)
@@ -27,6 +31,10 @@ func StartCron(client FuelPricesClient, repo FuelPricesRepository) (*cron.Cron, 
 	}
 
 	if _, err := c.AddFunc(CRON_SCHEDULE_PRICES, func() {
+		if !client.ShouldRefresh() {
+			log.Print("Skipping fuel prices fetch due to refresh policy")
+			return
+		}
 		numPrices, dropped, err := client.GetFuelPrices(repo.InsertPrices)
 		if err != nil {
 			log.Printf("Error fetching fuel prices: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ func main() {
 	var filePath string
 	var port int
 	var debug bool
-	var fullRefresh bool
+	var refresh string
 
 	rootCmd := &cobra.Command{
 		Use:  "fuel-prices",
@@ -22,10 +22,10 @@ func main() {
 	}
 
 	apiServerCmd := &cobra.Command{
-		Use:   "api-server [--db <path>] [--port <port>] [--debug]",
+		Use:   "api-server [--db <path>] [--port <port>] [--debug] [--refresh=full|never|incremental]",
 		Short: "Start HTTP API server",
 		Run: func(_ *cobra.Command, _ []string) {
-			if err = cmd.ApiServer(dbPath, port, fullRefresh, debug); err != nil {
+			if err = cmd.ApiServer(dbPath, port, refresh, debug); err != nil {
 				log.Fatalf("API Server failed: %v", err)
 			}
 		},
@@ -54,7 +54,7 @@ func main() {
 
 	apiServerCmd.Flags().IntVar(&port, "port", 8080, "Port to run HTTP server on")
 	apiServerCmd.Flags().BoolVar(&debug, "debug", false, "Enable debugging (pprof) - WARING: do not enable in production")
-	apiServerCmd.Flags().BoolVar(&fullRefresh, "full-refresh", false, "if set, always fetch all PFS and fuel prices, else only fetch updated stations/prices since last successful fetch")
+	apiServerCmd.Flags().StringVar(&refresh, "refresh", "incremental", "when set to 'full', always fetch all PFS and fuel prices, when set to 'never' never fetch from fuel finder API, else only fetch updated stations/prices since last successful fetch")
 
 	rootCmd.AddCommand(apiServerCmd)
 	rootCmd.AddCommand(importCmd)


### PR DESCRIPTION
Introduced a string-based `refresh` configuration to replace the boolean `fullRefresh` flag. This allows for more granular control over data synchronization.

- Supported values: `full`, `never`, `incremental`.
- Prevents fetching in CRON jobs when set to `never`.

```mermaid
graph LR
    A[Cron Job] --> B{ShouldRefresh?}
    B -- never --> C[Skip]
    B -- incremental --> D[Fetch Updates]
    B -- full --> E[Fetch All]
```