### PR TITLE
refactor: track absolute token expiry times

### DIFF
--- a/internal/client_fetch.go
+++ b/internal/client_fetch.go
@@ -58,10 +58,11 @@ type FuelPricesClient interface {
 }
 
 type timeTracker struct {
-	started         time.Time
-	lastAuth        time.Time
-	lastPfsFetch    time.Time
-	lastPricesFetch time.Time
+	started            time.Time
+	accessTokenExpiry  time.Time
+	refreshTokenExpiry time.Time
+	lastPfsFetch       time.Time
+	lastPricesFetch    time.Time
 }
 
 type fuelPricesManager struct {
@@ -161,13 +162,20 @@ func (mgr *fuelPricesManager) authenticate() error {
 	}
 
 	mgr.tokenData = resp.Data
-	mgr.timeTracker.lastAuth = time.Now()
-	log.Printf("Authenticated successfully, token expires in %d seconds", resp.Data.ExpiresIn)
+	now := time.Now()
+	mgr.timeTracker.accessTokenExpiry = now.Add(time.Duration(resp.Data.ExpiresIn) * time.Second)
+	mgr.timeTracker.refreshTokenExpiry = now.Add(time.Duration(resp.Data.RefreshTokenExpiresIn) * time.Second)
+	log.Printf("Authenticated successfully, access token expires in %d seconds at %s", resp.Data.ExpiresIn, mgr.timeTracker.accessTokenExpiry.Format(time.RFC3339))
+	log.Printf("Refresh token expires in %d seconds at %s", resp.Data.RefreshTokenExpiresIn, mgr.timeTracker.refreshTokenExpiry.Format(time.RFC3339))
 
 	return nil
 }
 
 func (mgr *fuelPricesManager) tokenRefresh() error {
+	if expiresSoon(mgr.timeTracker.refreshTokenExpiry) {
+		log.Printf("Refresh token has either expired or is expiring soon, re-authenticating...")
+		return mgr.authenticate()
+	}
 
 	tokenReq := models.TokenRefreshRequest{
 		ClientId:     mgr.authReq.ClientId,
@@ -201,17 +209,14 @@ func (mgr *fuelPricesManager) tokenRefresh() error {
 
 	mgr.tokenData.AccessToken = resp.Data.AccessToken
 	mgr.tokenData.ExpiresIn = resp.Data.ExpiresIn
-	mgr.timeTracker.lastAuth = time.Now()
-	log.Printf("Token refresh completed successfully, token expires in %d seconds", mgr.tokenData.ExpiresIn)
+	mgr.timeTracker.accessTokenExpiry = time.Now().Add(time.Duration(resp.Data.ExpiresIn) * time.Second)
+	log.Printf("Token refresh completed successfully, access token expires in %d seconds at %s", resp.Data.ExpiresIn, mgr.timeTracker.accessTokenExpiry.Format(time.RFC3339))
 
 	return nil
 }
 
 func (mgr *fuelPricesManager) checkTokenExpiry() error {
-	expiryTime := mgr.timeTracker.lastAuth.Add(time.Duration(mgr.tokenData.ExpiresIn) * time.Second)
-	expiresSoon := time.Until(expiryTime) < 5*time.Minute
-
-	if expiresSoon {
+	if expiresSoon(mgr.timeTracker.accessTokenExpiry) {
 		log.Printf("Access token has either expired or is expiring soon, refreshing...")
 		if err := mgr.tokenRefresh(); err != nil {
 			return fmt.Errorf("failed to refresh token: %w", err)
@@ -362,4 +367,8 @@ func (mgr *fuelPricesManager) post(url, contentType string, data any) (io.ReadCl
 	}
 
 	return resp.Body, nil
+}
+
+func expiresSoon(t time.Time) bool {
+	return time.Until(t) < 5*time.Minute
 }

--- a/internal/client_fetch.go
+++ b/internal/client_fetch.go
@@ -164,10 +164,15 @@ func (mgr *fuelPricesManager) authenticate() error {
 	mgr.tokenData = resp.Data
 	now := time.Now()
 	mgr.timeTracker.accessTokenExpiry = now.Add(time.Duration(resp.Data.ExpiresIn) * time.Second)
-	mgr.timeTracker.refreshTokenExpiry = now.Add(time.Duration(resp.Data.RefreshTokenExpiresIn) * time.Second)
+	if resp.Data.RefreshTokenExpiresIn > 0 {
+		mgr.timeTracker.refreshTokenExpiry = now.Add(time.Duration(resp.Data.RefreshTokenExpiresIn) * time.Second)
+	} else {
+		mgr.timeTracker.refreshTokenExpiry = time.Time{}
+	}
 	log.Printf("Authenticated successfully, access token expires in %d seconds at %s", resp.Data.ExpiresIn, mgr.timeTracker.accessTokenExpiry.Format(time.RFC3339))
-	log.Printf("Refresh token expires in %d seconds at %s", resp.Data.RefreshTokenExpiresIn, mgr.timeTracker.refreshTokenExpiry.Format(time.RFC3339))
-
+	if !mgr.timeTracker.refreshTokenExpiry.IsZero() {
+		log.Printf("Refresh token expires in %d seconds at %s", resp.Data.RefreshTokenExpiresIn, mgr.timeTracker.refreshTokenExpiry.Format(time.RFC3339))
+	}
 	return nil
 }
 

--- a/internal/client_fetch.go
+++ b/internal/client_fetch.go
@@ -370,5 +370,5 @@ func (mgr *fuelPricesManager) post(url, contentType string, data any) (io.ReadCl
 }
 
 func expiresSoon(t time.Time) bool {
-	return time.Until(t) < 5*time.Minute
+	return !t.IsZero() && time.Until(t) < 5*time.Minute
 }

--- a/internal/client_fetch_test.go
+++ b/internal/client_fetch_test.go
@@ -70,9 +70,10 @@ func TestAuthenticate_Success(t *testing.T) {
 		resp := models.AuthResponse{
 			Success: true,
 			Data: models.TokenData{
-				AccessToken:  "test-access-token",
-				ExpiresIn:    3600,
-				RefreshToken: "test-refresh-token",
+				AccessToken:           "test-access-token",
+				ExpiresIn:             3600,
+				RefreshToken:          "test-refresh-token",
+				RefreshTokenExpiresIn: 86400,
 			},
 		}
 		w.WriteHeader(http.StatusOK)
@@ -89,6 +90,30 @@ func TestAuthenticate_Success(t *testing.T) {
 	assert.Equal(t, "test-refresh-token", mgr.tokenData.RefreshToken)
 	assert.False(t, mgr.timeTracker.accessTokenExpiry.IsZero())
 	assert.False(t, mgr.timeTracker.refreshTokenExpiry.IsZero())
+}
+
+func TestAuthenticate_NoRefreshTokenExpiry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := models.AuthResponse{
+			Success: true,
+			Data: models.TokenData{
+				AccessToken:  "test-access-token",
+				ExpiresIn:    3600,
+				RefreshToken: "test-refresh-token",
+				// RefreshTokenExpiresIn is 0
+			},
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	mgr := setupTestClient(t, server.URL)
+	err := mgr.authenticate()
+
+	require.NoError(t, err)
+	assert.False(t, mgr.timeTracker.accessTokenExpiry.IsZero())
+	assert.True(t, mgr.timeTracker.refreshTokenExpiry.IsZero())
 }
 
 func TestAuthenticate_Failure(t *testing.T) {

--- a/internal/client_fetch_test.go
+++ b/internal/client_fetch_test.go
@@ -36,16 +36,22 @@ func TestHTTPStatusError_Error(t *testing.T) {
 }
 
 func setupTestClient(t *testing.T, baseUrl string) *fuelPricesManager {
+	now := time.Now()
 	return &fuelPricesManager{
 		baseUrl: baseUrl,
 		timeTracker: timeTracker{
-			started: time.Now(),
+			started:            now,
+			accessTokenExpiry:  now.Add(1 * time.Hour),
+			refreshTokenExpiry: now.Add(24 * time.Hour),
 		},
 		refresh: "incremental",
 		client:  &http.Client{},
 		authReq: models.AuthRequest{
 			ClientId:     "test-client-id",
 			ClientSecret: "test-client-secret",
+		},
+		tokenData: models.TokenData{
+			RefreshTokenExpiresIn: 86400, // 24 hours
 		},
 		metrics: metrics.NewClientFetchMetrics(prometheus.NewRegistry()),
 	}
@@ -81,7 +87,8 @@ func TestAuthenticate_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "test-access-token", mgr.tokenData.AccessToken)
 	assert.Equal(t, "test-refresh-token", mgr.tokenData.RefreshToken)
-	assert.False(t, mgr.timeTracker.lastAuth.IsZero())
+	assert.False(t, mgr.timeTracker.accessTokenExpiry.IsZero())
+	assert.False(t, mgr.timeTracker.refreshTokenExpiry.IsZero())
 }
 
 func TestAuthenticate_Failure(t *testing.T) {
@@ -202,14 +209,14 @@ func TestCheckTokenExpiry(t *testing.T) {
 	mgr := setupTestClient(t, server.URL)
 
 	// Not expired
-	mgr.timeTracker.lastAuth = time.Now()
+	mgr.timeTracker.accessTokenExpiry = time.Now().Add(1 * time.Hour)
 	mgr.tokenData.ExpiresIn = 3600
 	err := mgr.checkTokenExpiry()
 	require.NoError(t, err)
 	assert.Empty(t, mgr.tokenData.AccessToken) // No refresh happened
 
 	// Expiring soon
-	mgr.timeTracker.lastAuth = time.Now().Add(-56 * time.Minute)
+	mgr.timeTracker.accessTokenExpiry = time.Now().Add(4 * time.Minute)
 	mgr.tokenData.ExpiresIn = 3600 // expires in 4 mins
 	err = mgr.checkTokenExpiry()
 	require.NoError(t, err)
@@ -234,7 +241,7 @@ func TestGetFuelPrices_Success(t *testing.T) {
 
 	mgr := setupTestClient(t, server.URL)
 	mgr.tokenData.ExpiresIn = 3600
-	mgr.timeTracker.lastAuth = time.Now()
+	mgr.timeTracker.accessTokenExpiry = time.Now().Add(1 * time.Hour)
 
 	count, dropped, err := mgr.GetFuelPrices(func(batch []models.ForecourtPrices) (int, int, error) {
 		return len(batch), 0, nil
@@ -263,7 +270,7 @@ func TestGetFillingStations_Success(t *testing.T) {
 
 	mgr := setupTestClient(t, server.URL)
 	mgr.tokenData.ExpiresIn = 3600
-	mgr.timeTracker.lastAuth = time.Now()
+	mgr.timeTracker.accessTokenExpiry = time.Now().Add(1 * time.Hour)
 
 	count, dropped, err := mgr.GetFillingStations(func(batch []models.PetrolFillingStation) (int, int, error) {
 		return len(batch), 0, nil
@@ -307,7 +314,7 @@ func TestFetchBatched_CallbackError(t *testing.T) {
 
 	mgr := setupTestClient(t, server.URL)
 	mgr.tokenData.ExpiresIn = 3600
-	mgr.timeTracker.lastAuth = time.Now()
+	mgr.timeTracker.accessTokenExpiry = time.Now().Add(1 * time.Hour)
 
 	_, _, err := mgr.GetFuelPrices(func(batch []models.ForecourtPrices) (int, int, error) {
 		return 0, 0, fmt.Errorf("callback failed")
@@ -332,7 +339,7 @@ func TestGetFuelPrices_DecodeError(t *testing.T) {
 
 	mgr := setupTestClient(t, server.URL)
 	mgr.tokenData.ExpiresIn = 3600
-	mgr.timeTracker.lastAuth = time.Now()
+	mgr.timeTracker.accessTokenExpiry = time.Now().Add(1 * time.Hour)
 
 	_, _, err := mgr.GetFuelPrices(nil)
 	require.Error(t, err)
@@ -346,8 +353,8 @@ func TestFetchBatched_TokenExpiryError(t *testing.T) {
 	defer server.Close()
 
 	mgr := setupTestClient(t, server.URL)
-	mgr.timeTracker.lastAuth = time.Now().Add(-1 * time.Hour)
-	mgr.tokenData.ExpiresIn = 1800 // expired
+	mgr.timeTracker.accessTokenExpiry = time.Now().Add(-1 * time.Minute) // already expired
+	mgr.tokenData.ExpiresIn = 1800
 
 	_, _, err := mgr.GetFuelPrices(nil)
 	require.Error(t, err)

--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -12,10 +12,11 @@ type AuthResponse struct {
 }
 
 type TokenData struct {
-	AccessToken  string `json:"access_token"`
-	TokenType    string `json:"token_type"`
-	ExpiresIn    int    `json:"expires_in"`
-	RefreshToken string `json:"refresh_token,omitempty"`
+	AccessToken           string `json:"access_token"`
+	TokenType             string `json:"token_type"`
+	ExpiresIn             int    `json:"expires_in"`
+	RefreshToken          string `json:"refresh_token,omitempty"`
+	RefreshTokenExpiresIn int `json:"refresh_token_expires_in,omitempty"`
 }
 
 type TokenRefreshRequest struct {


### PR DESCRIPTION
- Replaced relative `lastAuth` timestamp with absolute `accessTokenExpiry`
  and `refreshTokenExpiry` fields.
- Added explicit support for `refresh_token_expires_in`.
- Updated `tokenRefresh` to re-authenticate when the refresh token nears expiry.

```mermaid
sequenceDiagram
    participant Client
    participant API
    Client->>API: authenticate()
    API-->>Client: Returns access & refresh tokens
    Note over Client: Stores absolute expiry times
    Client->>Client: checkTokenExpiry()
    alt Refresh Token Expired
        Client->>API: authenticate()
    else Access Token Expiring Soon
        Client->>API: tokenRefresh()
    end
```