### PR TITLE
fix: token refresh and recovery logic to prevent periodic 401s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ gemini-artifacts/
 
 # GitHub App credentials
 gha-creds-*.json
+.antigravitycli/

--- a/internal/client_fetch.go
+++ b/internal/client_fetch.go
@@ -190,7 +190,7 @@ func (mgr *fuelPricesManager) tokenRefresh() error {
 	body, err := mgr.post(url, "application/json", tokenReq)
 	if err != nil {
 		var stErr *HTTPStatusError
-		if errors.As(err, &stErr) && stErr.StatusCode >= http.StatusInternalServerError {
+		if errors.As(err, &stErr) {
 			log.Printf("Failed to refresh access token: %v", err)
 			log.Printf("Trying to recover from token refresh error response (HTTP %d)...", stErr.StatusCode)
 			return mgr.authenticate()
@@ -215,6 +215,14 @@ func (mgr *fuelPricesManager) tokenRefresh() error {
 	mgr.tokenData.AccessToken = resp.Data.AccessToken
 	mgr.tokenData.ExpiresIn = resp.Data.ExpiresIn
 	mgr.timeTracker.accessTokenExpiry = time.Now().Add(time.Duration(resp.Data.ExpiresIn) * time.Second)
+	if resp.Data.RefreshToken != "" {
+		mgr.tokenData.RefreshToken = resp.Data.RefreshToken
+		if resp.Data.RefreshTokenExpiresIn > 0 {
+			mgr.timeTracker.refreshTokenExpiry = time.Now().Add(time.Duration(resp.Data.RefreshTokenExpiresIn) * time.Second)
+		} else {
+			mgr.timeTracker.refreshTokenExpiry = time.Time{}
+		}
+	}
 	log.Printf("Token refresh completed successfully, access token expires in %d seconds at %s", resp.Data.ExpiresIn, mgr.timeTracker.accessTokenExpiry.Format(time.RFC3339))
 
 	return nil
@@ -247,10 +255,6 @@ func fetchBatched[T any](
 	decode func(io.ReadCloser, int) ([]T, error),
 	callback BatchCallback[T],
 ) (int, int, error) {
-	if err := mgr.checkTokenExpiry(); err != nil {
-		return 0, 0, err
-	}
-
 	batchNo := 1
 	count := 0
 	totalDropped := 0
@@ -259,6 +263,10 @@ func fetchBatched[T any](
 	effectiveStartTimestamp := mgr.getEffectiveStartTimestamp(path, lastFetch)
 
 	for {
+		if err := mgr.checkTokenExpiry(); err != nil {
+			return 0, 0, err
+		}
+
 		params := neturl.Values{}
 		params.Add("batch-number", strconv.Itoa(batchNo))
 		if effectiveStartTimestamp != "" {

--- a/internal/client_fetch.go
+++ b/internal/client_fetch.go
@@ -212,13 +212,15 @@ func (mgr *fuelPricesManager) tokenRefresh() error {
 		return fmt.Errorf("authentication failed: %s", resp.Message)
 	}
 
+	now := time.Now()
 	mgr.tokenData.AccessToken = resp.Data.AccessToken
 	mgr.tokenData.ExpiresIn = resp.Data.ExpiresIn
-	mgr.timeTracker.accessTokenExpiry = time.Now().Add(time.Duration(resp.Data.ExpiresIn) * time.Second)
+	mgr.timeTracker.accessTokenExpiry = now.Add(time.Duration(resp.Data.ExpiresIn) * time.Second)
 	if resp.Data.RefreshToken != "" {
 		mgr.tokenData.RefreshToken = resp.Data.RefreshToken
+		mgr.tokenData.RefreshTokenExpiresIn = resp.Data.RefreshTokenExpiresIn
 		if resp.Data.RefreshTokenExpiresIn > 0 {
-			mgr.timeTracker.refreshTokenExpiry = time.Now().Add(time.Duration(resp.Data.RefreshTokenExpiresIn) * time.Second)
+			mgr.timeTracker.refreshTokenExpiry = now.Add(time.Duration(resp.Data.RefreshTokenExpiresIn) * time.Second)
 		} else {
 			mgr.timeTracker.refreshTokenExpiry = time.Time{}
 		}

--- a/internal/client_fetch_test.go
+++ b/internal/client_fetch_test.go
@@ -265,7 +265,7 @@ func TestTokenRefresh_UpdatesRefreshToken(t *testing.T) {
 
 	mgr := setupTestClient(t, server.URL)
 	mgr.tokenData.RefreshToken = "old-refresh-token"
-	
+
 	err := mgr.tokenRefresh()
 	require.NoError(t, err)
 	assert.Equal(t, "new-access-token", mgr.tokenData.AccessToken)

--- a/internal/client_fetch_test.go
+++ b/internal/client_fetch_test.go
@@ -221,6 +221,58 @@ func TestTokenRefresh_RetryOnServerError(t *testing.T) {
 	assert.Equal(t, 2, calls)
 }
 
+func TestTokenRefresh_RecoverOnClientError(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if r.URL.Path == "/oauth/regenerate_access_token" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path == "/oauth/generate_access_token" {
+			resp := models.AuthResponse{
+				Success: true,
+				Data:    models.TokenData{AccessToken: "recovered-token", ExpiresIn: 3600},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+	}))
+	defer server.Close()
+
+	mgr := setupTestClient(t, server.URL)
+	err := mgr.tokenRefresh()
+
+	require.NoError(t, err)
+	assert.Equal(t, "recovered-token", mgr.tokenData.AccessToken)
+	assert.Equal(t, 2, calls)
+}
+
+func TestTokenRefresh_UpdatesRefreshToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := models.AuthResponse{
+			Success: true,
+			Data: models.TokenData{
+				AccessToken:           "new-access-token",
+				ExpiresIn:             3600,
+				RefreshToken:          "new-refresh-token",
+				RefreshTokenExpiresIn: 7200,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	mgr := setupTestClient(t, server.URL)
+	mgr.tokenData.RefreshToken = "old-refresh-token"
+	
+	err := mgr.tokenRefresh()
+	require.NoError(t, err)
+	assert.Equal(t, "new-access-token", mgr.tokenData.AccessToken)
+	assert.Equal(t, "new-refresh-token", mgr.tokenData.RefreshToken)
+	assert.False(t, mgr.timeTracker.refreshTokenExpiry.IsZero())
+}
+
 func TestCheckTokenExpiry(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := models.AuthResponse{


### PR DESCRIPTION
Updates refresh token on refresh and falls back to full client-credentials authentication if token refresh fails with client errors like 400 or 401. Also checks token validity on every iteration of batched fetch.