### PR TITLE
refactor: replace log with structured slog

### DIFF
--- a/cmd/api_server.go
+++ b/cmd/api_server.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/Depado/ginprom"
@@ -13,6 +13,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/map-services/fuel-prices-api/internal"
+	"github.com/map-services/fuel-prices-api/internal/middleware"
 	"github.com/map-services/fuel-prices-api/internal/routes"
 	healthcheck "github.com/tavsec/gin-healthcheck"
 	"github.com/tavsec/gin-healthcheck/checks"
@@ -27,7 +28,7 @@ func ApiServer(dbPath string, port int, refresh string, debug bool) error {
 	}
 	defer func() {
 		if err := repo.Close(); err != nil {
-			log.Printf("failed to close repository: %v", err)
+			slog.Error("failed to close repository", "error", err)
 		}
 	}()
 
@@ -45,14 +46,14 @@ func ApiServer(dbPath string, port int, refresh string, debug bool) error {
 
 	r.Use(
 		gin.Recovery(),
-		gin.LoggerWithWriter(gin.DefaultWriter, "/healthz", "/metrics"),
+		middleware.RequestLogger(slog.Default(), "/healthz", "/metrics"),
 		prometheus.Instrument(),
 		compress.Compress(),
 		cors.Default(),
 	)
 
 	if debug {
-		log.Println("WARNING: pprof endpoints are enabled and exposed. Do not run with this flag in production.")
+		slog.Warn("pprof endpoints are enabled and exposed. Do not run with this flag in production.")
 		pprof.Register(r)
 	}
 
@@ -78,7 +79,7 @@ func ApiServer(dbPath string, port int, refresh string, debug bool) error {
 	v1.GET("/stats/distribution", routes.DistributionStats(repo))
 
 	addr := fmt.Sprintf(":%d", port)
-	log.Printf("Starting HTTP API Server on port %d...", port)
+	slog.Info("Starting HTTP API Server", "port", port)
 	if err := r.Run(addr); err != nil && err != http.ErrServerClosed {
 		return fmt.Errorf("HTTP API Server failed to start on port %d: %v", port, err)
 	}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"time"
 
@@ -22,7 +22,7 @@ import (
 // if something failed during startup.
 func bootstrap(dbPath, refresh string, debug bool) (internal.FuelPricesClient, internal.FuelPricesRepository, error) {
 	if err := godotenv.Load(); err != nil {
-		log.Println("No .env file found")
+		slog.Warn("No .env file found")
 	}
 
 	environment := "development"
@@ -41,9 +41,8 @@ func bootstrap(dbPath, refresh string, debug bool) (internal.FuelPricesClient, i
 	}
 	defer sentry.Flush(2 * time.Second)
 
-	godx.GitVersion()
-	godx.EnvironmentVars()
-	godx.UserInfo()
+	logger := internal.SetupLogger()
+	godx.Diagnostics(logger)
 
 	clientId := os.Getenv("CLIENT_ID")
 	clientSecret := os.Getenv("CLIENT_SECRET")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 )
 
 func Import(dbPath string) error {
@@ -13,7 +13,7 @@ func Import(dbPath string) error {
 	}
 	defer func() {
 		if err := repo.Close(); err != nil {
-			log.Printf("failed to close repository: %v", err)
+			slog.Error("failed to close repository", "error", err)
 		}
 	}()
 
@@ -21,13 +21,13 @@ func Import(dbPath string) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch filling stations: %w", err)
 	}
-	log.Printf("imported %d filling stations (dropped: %d)", numPFS, dropped)
+	slog.Info("imported filling stations", "count", numPFS, "dropped", dropped)
 
 	numPrices, dropped, err := client.GetFuelPrices(repo.InsertPrices)
 	if err != nil {
 		return fmt.Errorf("failed to fetch fuel prices: %w", err)
 	}
-	log.Printf("imported %d fuel prices (dropped: %d)", numPrices, dropped)
+	slog.Info("imported fuel prices", "count", numPrices, "dropped", dropped)
 
 	return nil
 }

--- a/cmd/update_favicons.go
+++ b/cmd/update_favicons.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"encoding/csv"
-	"log"
+	"log/slog"
 	"os"
 
 	"github.com/cockroachdb/errors"
@@ -21,11 +21,11 @@ func UpdateFaviconsInCSV(csvFile string) error {
 	updated := make([]*models.Retailer, 0, len(retailers))
 	for idx, record := range retailers {
 
-		log.Printf("Processing record %d: %s", idx, record.WebsiteUrl)
+		slog.Info("Processing record", "index", idx, "url", record.WebsiteUrl)
 
 		iconInfo, err := favicon.Extract(record.WebsiteUrl)
 		if err != nil {
-			log.Printf("failed to extract favicon for %s: %v", record.WebsiteUrl, err)
+			slog.Error("failed to extract favicon", "url", record.WebsiteUrl, "error", err)
 		} else {
 			record.LogoUrl = &iconInfo.Href
 		}
@@ -38,7 +38,7 @@ func UpdateFaviconsInCSV(csvFile string) error {
 	}
 	defer func() {
 		if err := f.Close(); err != nil {
-			log.Printf("error closing file: %v", err)
+			slog.Error("error closing file", "error", err)
 		}
 	}()
 

--- a/internal/client_fetch.go
+++ b/internal/client_fetch.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	neturl "net/url"
 	"os"
@@ -148,7 +148,7 @@ func (mgr *fuelPricesManager) authenticate() error {
 	}
 	defer func() {
 		if err := body.Close(); err != nil {
-			log.Printf("failed to close body: %v", err)
+			slog.Error("failed to close body", "error", err)
 		}
 	}()
 
@@ -169,16 +169,16 @@ func (mgr *fuelPricesManager) authenticate() error {
 	} else {
 		mgr.timeTracker.refreshTokenExpiry = time.Time{}
 	}
-	log.Printf("Authenticated successfully, access token expires in %d seconds at %s", resp.Data.ExpiresIn, mgr.timeTracker.accessTokenExpiry.Format(time.RFC3339))
+	slog.Info("Authenticated successfully", "expiresIn", resp.Data.ExpiresIn, "accessTokenExpiry", mgr.timeTracker.accessTokenExpiry.Format(time.RFC3339))
 	if !mgr.timeTracker.refreshTokenExpiry.IsZero() {
-		log.Printf("Refresh token expires in %d seconds at %s", resp.Data.RefreshTokenExpiresIn, mgr.timeTracker.refreshTokenExpiry.Format(time.RFC3339))
+		slog.Info("Refresh token expires", "expiresIn", resp.Data.RefreshTokenExpiresIn, "refreshTokenExpiry", mgr.timeTracker.refreshTokenExpiry.Format(time.RFC3339))
 	}
 	return nil
 }
 
 func (mgr *fuelPricesManager) tokenRefresh() error {
 	if expiresSoon(mgr.timeTracker.refreshTokenExpiry) {
-		log.Printf("Refresh token has either expired or is expiring soon, re-authenticating...")
+		slog.Warn("Refresh token has either expired or is expiring soon, re-authenticating...")
 		return mgr.authenticate()
 	}
 
@@ -191,15 +191,15 @@ func (mgr *fuelPricesManager) tokenRefresh() error {
 	if err != nil {
 		var stErr *HTTPStatusError
 		if errors.As(err, &stErr) {
-			log.Printf("Failed to refresh access token: %v", err)
-			log.Printf("Trying to recover from token refresh error response (HTTP %d)...", stErr.StatusCode)
+			slog.Error("Failed to refresh access token", "error", err)
+			slog.Warn("Trying to recover from token refresh error response", "statusCode", stErr.StatusCode)
 			return mgr.authenticate()
 		}
 		return err
 	}
 	defer func() {
 		if err := body.Close(); err != nil {
-			log.Printf("failed to close body: %v", err)
+			slog.Error("failed to close body", "error", err)
 		}
 	}()
 
@@ -225,14 +225,14 @@ func (mgr *fuelPricesManager) tokenRefresh() error {
 			mgr.timeTracker.refreshTokenExpiry = time.Time{}
 		}
 	}
-	log.Printf("Token refresh completed successfully, access token expires in %d seconds at %s", resp.Data.ExpiresIn, mgr.timeTracker.accessTokenExpiry.Format(time.RFC3339))
+	slog.Info("Token refresh completed successfully", "expiresIn", resp.Data.ExpiresIn, "accessTokenExpiry", mgr.timeTracker.accessTokenExpiry.Format(time.RFC3339))
 
 	return nil
 }
 
 func (mgr *fuelPricesManager) checkTokenExpiry() error {
 	if expiresSoon(mgr.timeTracker.accessTokenExpiry) {
-		log.Printf("Access token has either expired or is expiring soon, refreshing...")
+		slog.Warn("Access token has either expired or is expiring soon, refreshing...")
 		if err := mgr.tokenRefresh(); err != nil {
 			return fmt.Errorf("failed to refresh token: %w", err)
 		}
@@ -246,7 +246,7 @@ func (mgr *fuelPricesManager) getEffectiveStartTimestamp(path string, lastFetch 
 		return ""
 	}
 
-	log.Printf("Time since last fetch for %s: %s", path, time.Since(*lastFetch))
+	slog.Info("Time since last fetch", "path", path, "elapsed", time.Since(*lastFetch))
 	return lastFetch.Format("2006-01-02 15:04:05") // Not quite RFC3339 ...
 }
 
@@ -279,7 +279,7 @@ func fetchBatched[T any](
 		if err != nil {
 			var stErr *HTTPStatusError
 			if errors.As(err, &stErr) && stErr.StatusCode == http.StatusNotFound {
-				log.Printf("No more batches available for %s, stopping at batch %d", path, batchNo-1)
+				slog.Info("No more batches available", "path", path, "lastBatch", batchNo-1)
 				break
 			}
 			return 0, 0, err
@@ -312,7 +312,7 @@ func fetchBatched[T any](
 
 func (mgr *fuelPricesManager) get(url string) (io.ReadCloser, error) {
 	start := time.Now()
-	log.Printf("GET %s", url)
+	slog.Info("GET", "url", url)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -346,7 +346,7 @@ func (mgr *fuelPricesManager) get(url string) (io.ReadCloser, error) {
 
 func (mgr *fuelPricesManager) post(url, contentType string, data any) (io.ReadCloser, error) {
 	start := time.Now()
-	log.Printf("POST %s", url)
+	slog.Info("POST", "url", url)
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request body: %w", err)

--- a/internal/cron.go
+++ b/internal/cron.go
@@ -1,7 +1,7 @@
 package internal
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/robfig/cron/v3"
 )
@@ -13,34 +13,34 @@ func StartCron(client FuelPricesClient, repo FuelPricesRepository) (*cron.Cron, 
 
 	c := cron.New()
 
-	log.Print("Starting CRON jobs to update petrol filling stations and fuel prices")
+	slog.Info("Starting CRON jobs to update petrol filling stations and fuel prices")
 
 	if _, err := c.AddFunc(CRON_SCHEDULE_PFS, func() {
 		if !client.ShouldRefresh() {
-			log.Print("Skipping filling stations fetch due to refresh policy")
+			slog.Info("Skipping filling stations fetch due to refresh policy")
 			return
 		}
 		numPFS, dropped, err := client.GetFillingStations(repo.InsertPFS)
 		if err != nil {
-			log.Printf("Error fetching PFS: %v (dropped: %d) \n", err, dropped)
+			slog.Error("Error fetching PFS", "error", err, "dropped", dropped)
 			return
 		}
-		log.Printf("Inserted %d PFS", numPFS)
+		slog.Info("Inserted PFS", "count", numPFS)
 	}); err != nil {
 		return nil, err
 	}
 
 	if _, err := c.AddFunc(CRON_SCHEDULE_PRICES, func() {
 		if !client.ShouldRefresh() {
-			log.Print("Skipping fuel prices fetch due to refresh policy")
+			slog.Info("Skipping fuel prices fetch due to refresh policy")
 			return
 		}
 		numPrices, dropped, err := client.GetFuelPrices(repo.InsertPrices)
 		if err != nil {
-			log.Printf("Error fetching fuel prices: %v\n", err)
+			slog.Error("Error fetching fuel prices", "error", err)
 			return
 		}
-		log.Printf("Inserted %d fuel prices (dropped: %d) ", numPrices, dropped)
+		slog.Info("Inserted fuel prices", "count", numPrices, "dropped", dropped)
 	}); err != nil {
 		return nil, err
 	}

--- a/internal/db.go
+++ b/internal/db.go
@@ -16,7 +16,7 @@ import (
 type migrateLogger struct{}
 
 func (l *migrateLogger) Printf(format string, v ...interface{}) {
-	slog.Info("migration", "message", fmt.Sprintf(format, v...))
+	slog.Info("migration", "message", strings.TrimSpace(fmt.Sprintf(format, v...)))
 }
 
 func (l *migrateLogger) Verbose() bool {

--- a/internal/db.go
+++ b/internal/db.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	_ "embed"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
@@ -16,7 +16,7 @@ import (
 type migrateLogger struct{}
 
 func (l *migrateLogger) Printf(format string, v ...interface{}) {
-	log.Printf("migration: "+format, v...)
+	slog.Info("migration", "message", fmt.Sprintf(format, v...))
 }
 
 func (l *migrateLogger) Verbose() bool {
@@ -31,7 +31,7 @@ func Migrate(migrationsPath, dbPath string) error {
 	m.Log = &migrateLogger{}
 	defer func() {
 		if sErr, dErr := m.Close(); sErr != nil || dErr != nil {
-			log.Printf("migration close error: source=%v, db=%v", sErr, dErr)
+			slog.Error("migration close error", "source", sErr, "db", dErr)
 		}
 	}()
 
@@ -60,6 +60,6 @@ func Connect(dbPath string) (*sql.DB, error) {
 	if err = db.Ping(); err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
-	log.Printf("connected to database: %s", dsn)
+	slog.Info("connected to database", "dsn", dsn)
 	return db, nil
 }

--- a/internal/favicon/extractor.go
+++ b/internal/favicon/extractor.go
@@ -2,7 +2,7 @@ package favicon
 
 import (
 	"crypto/tls"
-	"log"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"sort"
@@ -83,7 +83,7 @@ func Extract(url string) (*IconInfo, error) {
 	}
 	defer func() {
 		if err := res.Body.Close(); err != nil {
-			log.Printf("failed to close request body: %v", err)
+			slog.Error("failed to close request body", "error", err)
 		}
 	}()
 

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -1,0 +1,16 @@
+package internal
+
+import (
+	"log/slog"
+	"os"
+)
+
+// SetupLogger configures the global logger to use a JSON handler.
+func SetupLogger() *slog.Logger {
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	})
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+	return logger
+}

--- a/internal/metrics/client_fetch_metrics.go
+++ b/internal/metrics/client_fetch_metrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 	"math"
 	"net/http"
 	"net/url"
@@ -66,7 +66,7 @@ func (m *ClientFetchMetrics) RecordHttpCall(start time.Time, method, endpoint st
 		u, parseErr := url.Parse(endpoint)
 		path := u.Path
 		if parseErr != nil {
-			log.Printf("failed to parse endpoint URL '%s' for metrics: %v", endpoint, parseErr)
+			slog.Error("failed to parse endpoint URL for metrics", "endpoint", endpoint, "error", parseErr)
 			path = "invalid_url"
 		}
 		m.ResponseLatency.WithLabelValues(path, method).Observe(time.Since(start).Seconds())

--- a/internal/metrics/distribution_metrics.go
+++ b/internal/metrics/distribution_metrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 	"strconv"
 
 	"github.com/map-services/fuel-prices-api/internal/models"
@@ -20,7 +20,7 @@ func (c *fuelPricesDistributionCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *fuelPricesDistributionCollector) Collect(ch chan<- prometheus.Metric) {
 	stats, err := c.distFunc()
 	if err != nil {
-		log.Printf("failed to collect fuel price distribution stats: %v", err)
+		slog.Error("failed to collect fuel price distribution stats", "error", err)
 		return
 	}
 

--- a/internal/metrics/snapshot_metrics.go
+++ b/internal/metrics/snapshot_metrics.go
@@ -1,7 +1,7 @@
 package metrics
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/map-services/fuel-prices-api/internal/models"
 	"github.com/prometheus/client_golang/prometheus"
@@ -27,7 +27,7 @@ func (c *fuelPricesSnapshotCollector) Describe(ch chan<- *prometheus.Desc) {
 func (c *fuelPricesSnapshotCollector) Collect(ch chan<- prometheus.Metric) {
 	stats, err := c.snapshotFunc()
 	if err != nil {
-		log.Printf("failed to collect fuel price snapshot stats: %v", err)
+		slog.Error("failed to collect fuel price snapshot stats", "error", err)
 		return
 	}
 

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -1,0 +1,41 @@
+package middleware
+
+import (
+	"log/slog"
+	"slices"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequestLogger is a middleware that logs details about every incoming request.
+func RequestLogger(logger *slog.Logger, excludedPaths ...string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		path := c.Request.URL.Path
+		raw := c.Request.URL.RawQuery
+
+		c.Next()
+
+		if slices.Contains(excludedPaths, c.Request.URL.Path) {
+			return
+		}
+
+		if raw != "" {
+			path = path + "?" + raw
+		}
+
+		end := time.Now()
+		latency := end.Sub(start)
+
+		logger.Info("request",
+			"method", c.Request.Method,
+			"path", path,
+			"status", c.Writer.Status(),
+			"latency_ms", latency.Milliseconds(),
+			"ip", c.ClientIP(),
+			"user_agent", c.Request.UserAgent(),
+			"body_size", c.Writer.Size(),
+		)
+	}
+}

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -20,11 +20,17 @@ func RequestLogger(logger *slog.Logger, excludedPaths ...string) gin.HandlerFunc
 		c.Next()
 		latency := time.Since(start)
 
+		path := c.Request.URL.Path
+		raw := c.Request.URL.RawQuery
+		if raw != "" {
+			path = path + "?" + raw
+		}
+
 		logger.Info("request",
 			"method", c.Request.Method,
-			"path", c.Request.RequestURI,
+			"path", path,
 			"status", c.Writer.Status(),
-			"latency_ms", float64(latency.Microseconds()) / 1000.0,
+			"latency_ms", float64(latency.Microseconds())/1000.0,
 			"ip", c.ClientIP(),
 			"user_agent", c.Request.UserAgent(),
 			"body_size", c.Writer.Size(),

--- a/internal/middleware/logger.go
+++ b/internal/middleware/logger.go
@@ -11,28 +11,20 @@ import (
 // RequestLogger is a middleware that logs details about every incoming request.
 func RequestLogger(logger *slog.Logger, excludedPaths ...string) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		start := time.Now()
-		path := c.Request.URL.Path
-		raw := c.Request.URL.RawQuery
-
-		c.Next()
-
 		if slices.Contains(excludedPaths, c.Request.URL.Path) {
+			c.Next()
 			return
 		}
 
-		if raw != "" {
-			path = path + "?" + raw
-		}
-
-		end := time.Now()
-		latency := end.Sub(start)
+		start := time.Now()
+		c.Next()
+		latency := time.Since(start)
 
 		logger.Info("request",
 			"method", c.Request.Method,
-			"path", path,
+			"path", c.Request.RequestURI,
 			"status", c.Writer.Status(),
-			"latency_ms", latency.Milliseconds(),
+			"latency_ms", float64(latency.Microseconds()) / 1000.0,
 			"ip", c.ClientIP(),
 			"user_agent", c.Request.UserAgent(),
 			"body_size", c.Writer.Size(),

--- a/internal/middleware/logger_test.go
+++ b/internal/middleware/logger_test.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestLogger(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	t.Run("Logs standard paths", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		logger := slog.New(slog.NewTextHandler(buf, nil))
+
+		r := gin.New()
+		r.Use(RequestLogger(logger, "/healthz"))
+		r.GET("/test", func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		})
+
+		req, _ := http.NewRequest("GET", "/test", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, buf.String(), "method=GET")
+		assert.Contains(t, buf.String(), "path=/test")
+		assert.Contains(t, buf.String(), "latency_ms=")
+	})
+
+	t.Run("Excludes paths", func(t *testing.T) {
+		buf := &bytes.Buffer{}
+		logger := slog.New(slog.NewTextHandler(buf, nil))
+
+		r := gin.New()
+		r.Use(RequestLogger(logger, "/healthz"))
+		r.GET("/healthz", func(c *gin.Context) {
+			c.Status(http.StatusOK)
+		})
+
+		req, _ := http.NewRequest("GET", "/healthz", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Empty(t, buf.String(), "Log output should be empty for excluded path")
+	})
+}

--- a/internal/models/fuel_prices.go
+++ b/internal/models/fuel_prices.go
@@ -2,7 +2,8 @@ package models
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
+	"os"
 	"strings"
 	"time"
 
@@ -108,7 +109,7 @@ func (fp *FuelPrice) ToTuple(nodeId string) []any {
 
 	price, logMsg := cleansePrice(fp.Price)
 	if logMsg != "" {
-		log.Println(logMsg)
+		slog.Warn(logMsg)
 	}
 
 	return []any{
@@ -128,7 +129,8 @@ func (fp *FuelPrice) IsPriceOutOfBounds() bool {
 func toJSON(v any) string {
 	jsonBytes, err := json.Marshal(v)
 	if err != nil {
-		log.Fatalf("Error marshaling to JSON: %v", err)
+		slog.Error("error marshaling to JSON", "error", err)
+		os.Exit(1)
 	}
 	return string(jsonBytes)
 }

--- a/internal/repository.go
+++ b/internal/repository.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	_ "embed"
 	"fmt"
-	"log"
+	"log/slog"
 	"sort"
 	"sync"
 	"time"
@@ -89,7 +89,7 @@ func (repo *sqliteRepository) InsertPFS(batch []models.PetrolFillingStation) (in
 	defer func() {
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Printf("error rolling back transaction: %v", rbErr)
+				slog.Error("error rolling back transaction", "error", rbErr)
 			}
 		}
 	}()
@@ -100,7 +100,7 @@ func (repo *sqliteRepository) InsertPFS(batch []models.PetrolFillingStation) (in
 	}
 	defer func() {
 		if err := stmt.Close(); err != nil {
-			log.Printf("failed to close statement: %v", err)
+			slog.Error("failed to close statement", "error", err)
 		}
 	}()
 
@@ -133,7 +133,7 @@ func (repo *sqliteRepository) InsertPrices(batch []models.ForecourtPrices) (int,
 	defer func() {
 		if err != nil {
 			if rbErr := tx.Rollback(); rbErr != nil {
-				log.Printf("error rolling back transaction: %v", rbErr)
+				slog.Error("error rolling back transaction", "error", rbErr)
 			}
 		}
 	}()
@@ -144,7 +144,7 @@ func (repo *sqliteRepository) InsertPrices(batch []models.ForecourtPrices) (int,
 	}
 	defer func() {
 		if err := stmt.Close(); err != nil {
-			log.Printf("failed to close statement: %v", err)
+			slog.Error("failed to close statement", "error", err)
 		}
 	}()
 
@@ -153,7 +153,7 @@ func (repo *sqliteRepository) InsertPrices(batch []models.ForecourtPrices) (int,
 	for _, forecourtPrices := range batch {
 		for _, fuelPrice := range forecourtPrices.FuelPrices {
 			if fuelPrice.IsPriceOutOfBounds() {
-				log.Printf("WARNING: %s price of %0.2fp looks like an input-entry error; dropping fuel_price record for node_id: %s", fuelPrice.FuelType, fuelPrice.Price, forecourtPrices.NodeId)
+				slog.Warn("price looks like an input-entry error; dropping fuel_price record", "fuelType", fuelPrice.FuelType, "price", fuelPrice.Price, "nodeId", forecourtPrices.NodeId)
 				dropped++
 				continue
 			}
@@ -215,7 +215,7 @@ func (repo *sqliteRepository) fetchPfs(boundingBox []float64, results *[]models.
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
-			log.Printf("failed to close rows: %v", closeErr)
+			slog.Error("failed to close rows", "error", closeErr)
 		}
 	}()
 
@@ -267,7 +267,7 @@ func (repo *sqliteRepository) fetchPrices(boundingBox []float64, results *map[st
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
-			log.Printf("failed to close rows: %v", closeErr)
+			slog.Error("failed to close rows", "error", closeErr)
 		}
 	}()
 
@@ -315,7 +315,7 @@ func (repo *sqliteRepository) snapshotQuery() (*models.SnapshotStatistics, error
 	}
 	defer func() {
 		if closeErr := snapshotRows.Close(); closeErr != nil {
-			log.Printf("failed to close snapshot rows: %v", closeErr)
+			slog.Error("failed to close snapshot rows", "error", closeErr)
 		}
 	}()
 
@@ -349,7 +349,7 @@ func (repo *sqliteRepository) distributionQuery() (*models.DistributionStatistic
 	}
 	defer func() {
 		if closeErr := distributionRows.Close(); closeErr != nil {
-			log.Printf("failed to close distribution rows: %v", closeErr)
+			slog.Error("failed to close distribution rows", "error", closeErr)
 		}
 	}()
 
@@ -422,7 +422,7 @@ func (repo *sqliteRepository) PriceHistory(nodeId, fuelType string) ([]models.Fu
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
-			log.Printf("failed to close rows: %v", closeErr)
+			slog.Error("failed to close rows", "error", closeErr)
 		}
 	}()
 
@@ -457,7 +457,7 @@ func (repo *sqliteRepository) fuelTypesQuery() (map[string]struct{}, error) {
 	}
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
-			log.Printf("failed to close snapshot rows: %v", closeErr)
+			slog.Error("failed to close snapshot rows", "error", closeErr)
 		}
 	}()
 

--- a/internal/routes/price_history.go
+++ b/internal/routes/price_history.go
@@ -1,7 +1,7 @@
 package routes
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/map-services/fuel-prices-api/internal"
@@ -18,7 +18,7 @@ func PriceHistory(repo internal.FuelPricesRepository, client internal.FuelPrices
 
 		fuelTypes, err := repo.FuelTypes()
 		if err != nil {
-			log.Printf("error while fetching fuel types: %v", err)
+			slog.Error("error while fetching fuel types", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "An internal server error occurred"})
 			return
 		}
@@ -31,7 +31,7 @@ func PriceHistory(repo internal.FuelPricesRepository, client internal.FuelPrices
 		results, err := repo.PriceHistory(nodeId, fuelType)
 
 		if err != nil {
-			log.Printf("error while fetching price history: %v", err)
+			slog.Error("error while fetching price history", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "An internal server error occurred"})
 			return
 		}

--- a/internal/routes/search.go
+++ b/internal/routes/search.go
@@ -2,7 +2,7 @@ package routes
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"math"
 	"net/http"
 	"strconv"
@@ -39,7 +39,7 @@ func Search(repo internal.FuelPricesRepository, client internal.FuelPricesClient
 		results, err := repo.Search(bbox, limit)
 
 		if err != nil {
-			log.Printf("error while fetching fuel prices: %v", err)
+			slog.Error("error while fetching fuel prices", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "An internal server error occurred"})
 			return
 		}

--- a/internal/routes/stats.go
+++ b/internal/routes/stats.go
@@ -1,7 +1,7 @@
 package routes
 
 import (
-	"log"
+	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -14,7 +14,7 @@ func SnapshotStats(repo internal.FuelPricesRepository) func(c *gin.Context) {
 		stats, err := repo.SnapshotStats()
 
 		if err != nil {
-			log.Printf("error while fetching snapshot stats: %v", err)
+			slog.Error("error while fetching snapshot stats", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "An internal server error occurred"})
 			return
 		}
@@ -31,7 +31,7 @@ func DistributionStats(repo internal.FuelPricesRepository) func(c *gin.Context) 
 		stats, err := repo.DistributionStats()
 
 		if err != nil {
-			log.Printf("error while fetching distribution stats: %v", err)
+			slog.Error("error while fetching distribution stats", "error", err)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "An internal server error occurred"})
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"log"
+	"log/slog"
+	"os"
 
 	"github.com/map-services/fuel-prices-api/cmd"
 
@@ -26,7 +27,8 @@ func main() {
 		Short: "Start HTTP API server",
 		Run: func(_ *cobra.Command, _ []string) {
 			if err = cmd.ApiServer(dbPath, port, refresh, debug); err != nil {
-				log.Fatalf("API Server failed: %v", err)
+				slog.Error("API Server failed", "error", err)
+				os.Exit(1)
 			}
 		},
 	}
@@ -36,7 +38,8 @@ func main() {
 		Short: "Perform one-off import of fuel prices and filling stations from the GOV.UK API",
 		Run: func(_ *cobra.Command, _ []string) {
 			if err := cmd.Import(dbPath); err != nil {
-				log.Fatalf("Import failed: %v", err)
+				slog.Error("Import failed", "error", err)
+				os.Exit(1)
 			}
 		},
 	}
@@ -46,7 +49,8 @@ func main() {
 		Short: "Update favicons",
 		Run: func(_ *cobra.Command, _ []string) {
 			if err := cmd.UpdateFaviconsInCSV(filePath); err != nil {
-				log.Fatalf("Update favicons failed: %v", err)
+				slog.Error("Update favicons failed", "error", err)
+				os.Exit(1)
 			}
 		},
 	}
@@ -62,6 +66,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&dbPath, "db", "./data/fuel_prices.db", "Path to fuel-prices SQLite database")
 
 	if err = rootCmd.Execute(); err != nil {
-		log.Fatal(err)
+		slog.Error("fatal error", "error", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Migrated project logging to use `log/slog` for structured output. Implemented a new `middleware.RequestLogger` to provide detailed, structured request logging.

```mermaid
graph TD
    A[HTTP Request] --> B{RequestLogger Middleware}
    B -->|Log Request Data| C[slog.JSONHandler]
    C --> D[stderr]
```